### PR TITLE
Update efi_runtime.c: fix no_llseek

### DIFF
--- a/efi_runtime/efi_runtime.c
+++ b/efi_runtime/efi_runtime.c
@@ -763,7 +763,7 @@ static const struct file_operations efi_runtime_fops = {
 	.unlocked_ioctl	= efi_runtime_ioctl,
 	.open		= efi_runtime_open,
 	.release	= efi_runtime_close,
-	.llseek		= no_llseek,
+	.llseek		= NULL,
 };
 
 static struct miscdevice efi_runtime_dev = {


### PR DESCRIPTION
no_llseek has gone away in Linux 6.14. Per the migration document in the kernel, just use NULL now.